### PR TITLE
Added run number and other fields to TimeSync messages

### DIFF
--- a/include/readoutlibs/ReadoutLogging.hpp
+++ b/include/readoutlibs/ReadoutLogging.hpp
@@ -23,7 +23,8 @@ enum
   TLVL_WORK_STEPS = 10,
   TLVL_QUEUE_PUSH = 11,
   TLVL_QUEUE_POP = 12,
-  TLVL_BOOKKEEPING = 15
+  TLVL_BOOKKEEPING = 15,
+  TLVL_TIME_SYNCS = 17
 };
 
 } // namespace logging

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -611,7 +611,8 @@ protected:
           << "Oldest stored TS=" << last_ts << " "
           << "Start of window TS=" << start_win_ts << " "
           << "End of window TS=" << end_win_ts << " "
-          << "Estimated newest stored TS=" << newest_ts;
+          << "Estimated newest stored TS=" << newest_ts << " "
+          << "Requestor=" << dr.data_destination;
       TLOG_DEBUG(TLVL_WORK_STEPS) << oss.str();
     } else {
       ers::warning(RequestOnEmptyBuffer(ERS_HERE, m_geoid, "Data not found"));

--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -50,6 +50,7 @@
 
 using dunedaq::readoutlibs::logging::TLVL_QUEUE_POP;
 using dunedaq::readoutlibs::logging::TLVL_TAKE_NOTE;
+using dunedaq::readoutlibs::logging::TLVL_TIME_SYNCS;
 using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;
 
 namespace dunedaq {
@@ -77,7 +78,9 @@ public:
     , m_raw_processor_impl(nullptr)
     , m_requester_thread(0)
     , m_timesync_thread(0)
-  {}
+  {
+    m_pid_of_current_process = getpid();
+  }
 
   void init(const nlohmann::json& args)
   {
@@ -155,6 +158,8 @@ public:
     m_rawq_timeout_count = 0;
 
     m_t0 = std::chrono::high_resolution_clock::now();
+
+    m_run_number = args.value<dunedaq::daqdataformats::run_number_t>("run", 1);
 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Starting threads...";
     m_raw_processor_impl->start(args);
@@ -265,12 +270,18 @@ private:
     TLOG_DEBUG(TLVL_WORK_STEPS) << "TimeSync thread started...";
     m_num_requests = 0;
     m_sum_requests = 0;
+    size_t msg_seqno = 0;
     auto once_per_run = true;
     while (m_run_marker.load()) {
       try {
         auto timesyncmsg = dfmessages::TimeSync(m_raw_processor_impl->get_last_daq_time());
-        // TLOG() << "New timesync: daq=" << timesyncmsg.daq_time << " wall=" << timesyncmsg.system_time;
         if (timesyncmsg.daq_time != 0) {
+          timesyncmsg.run_number = m_run_number;
+          timesyncmsg.sequence_number = ++msg_seqno;
+          timesyncmsg.source_pid = m_pid_of_current_process;
+          TLOG_DEBUG(TLVL_TIME_SYNCS) << "New timesync: daq=" << timesyncmsg.daq_time
+                                      << " wall=" << timesyncmsg.system_time << " run=" << timesyncmsg.run_number
+                                      << " seqno=" << timesyncmsg.sequence_number << " pid=" << timesyncmsg.source_pid;
           try {
             auto serialised_timesync = dunedaq::serialization::serialize(timesyncmsg, dunedaq::serialization::kMsgPack);
             networkmanager::NetworkManager::get().send_to(m_timesync_connection_name,
@@ -366,6 +377,7 @@ private:
   bool m_fake_trigger;
   int m_current_fake_trigger_id;
   daqdataformats::GeoID m_geoid;
+  daqdataformats::run_number_t m_run_number;
 
   // STATS
   std::atomic<int> m_num_payloads{ 0 };
@@ -410,6 +422,7 @@ private:
   ReusableThread m_timesync_thread;
   std::string m_timesync_connection_name;
   std::string m_timesync_topic_name;
+  size_t m_pid_of_current_process;
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };

--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -270,7 +270,7 @@ private:
     TLOG_DEBUG(TLVL_WORK_STEPS) << "TimeSync thread started...";
     m_num_requests = 0;
     m_sum_requests = 0;
-    size_t msg_seqno = 0;
+    uint64_t msg_seqno = 0;
     auto once_per_run = true;
     while (m_run_marker.load()) {
       try {
@@ -422,7 +422,7 @@ private:
   ReusableThread m_timesync_thread;
   std::string m_timesync_connection_name;
   std::string m_timesync_topic_name;
-  size_t m_pid_of_current_process;
+  uint32_t m_pid_of_current_process;
 
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 };


### PR DESCRIPTION
This PullRequest is for changes related to the addition of a run number, sequence number, and source process PID to TimeSync messages.  The run number will be used to ensure that only TimeSync messages from the current run are used, and the sequence number and source_pid fields are included for debugging purposes.  (For example, I’ve used the source_pid to verify that only TimeSyncs from Readout App 1 show up in DQM App 1, etc, *and* that all TimeSync messages show up in the Fake HSI App.)

There are correlated code changes in four repositories for this addition.
dfmessages, branch kbiery/TimeSyncRunNumber
dqm, branch kbiery/TimeSyncRunNumber
readoutlibs, branch kbiery/TimeSyncRunNumber
timinglibs, branch kbiery/TimeSyncRunNumber

Reviewer(s), please take a look at the changes and verify that things are working correctly.  Once the changes in all four packages have been reviewed, we’ll merge them to the respective develop branches.
Thanks!

P.S. For better or worse, I included the change from PR #3 in this PR, so if/when this one gets approved and merged, we can delete #3.
