### PR TITLE
New implementation for the rate limiter and fix for the tests

### DIFF
--- a/include/readoutlibs/utils/RateLimiter.hpp
+++ b/include/readoutlibs/utils/RateLimiter.hpp
@@ -69,8 +69,19 @@ public:
     if (m_now > m_deadline + m_max_overshoot) {
       m_deadline = m_now + m_period.load();
     } else {
-      while (m_now < m_deadline) {
-        m_now = gettime();
+      if (m_now < m_deadline) {
+        if (m_deadline - m_now > 0) {
+          timespec tim;
+          tim.tv_sec = 0;
+          tim.tv_nsec = m_deadline - m_now;
+          // The second argument will be overwritten but we
+          // do not care about this temporary variable
+          nanosleep(&tim, &tim);
+          m_now = gettime();
+        }
+        while (m_now < m_deadline) {
+            m_now = gettime();
+        }
       }
       m_deadline += m_period.load();
     }

--- a/test/apps/test_ratelimiter_app.cxx
+++ b/test/apps/test_ratelimiter_app.cxx
@@ -90,6 +90,9 @@ main(int /*argc*/, char** /*argv[]*/)
   if (killswitch.joinable()) {
     killswitch.join();
   }
+  if (stats.joinable()) {
+    stats.join();
+  }
 
   // Check
   // TLOG() << "Operations in 5 seconds (should be really close to 5 million:): " << sumops;

--- a/test/apps/test_ratelimiter_app.cxx
+++ b/test/apps/test_ratelimiter_app.cxx
@@ -93,6 +93,9 @@ main(int /*argc*/, char** /*argv[]*/)
   if (stats.joinable()) {
     stats.join();
   }
+  if (adjuster.joinable()) {
+    adjuster.join();
+  }
 
   // Check
   // TLOG() << "Operations in 5 seconds (should be really close to 5 million:): " << sumops;

--- a/test/apps/test_ratelimiter_app.cxx
+++ b/test/apps/test_ratelimiter_app.cxx
@@ -12,9 +12,7 @@
 
 #include <atomic>
 #include <chrono>
-#include <memory>
 #include <random>
-#include <string>
 #include <vector>
 
 using namespace dunedaq::readoutlibs;

--- a/test/apps/test_skiplist_app.cxx
+++ b/test/apps/test_skiplist_app.cxx
@@ -198,6 +198,9 @@ main(int /*argc*/, char** /*argv[]*/)
   if (extractor.joinable()) {
     extractor.join();
   }
+  if (adjuster.joinable()) {
+    adjuster.join();
+  }
 
   // Exit
   TLOG() << "Exiting.";


### PR DESCRIPTION
The current implementation is polling continuously to get the current time. I changed it to sleep so that CPU usage is almost zero while inside the rate limiter and while at it fixed the ratelimiter and skiplist tests, they exit normally instead of crashing. About my testing:

- Tested with the ratelimiter test at 1 MHz, 100 kHz, 10 kHz and 7 kHz, rate is what is supposed to be and CPU usage is almost zero
- When running I have checked that the opmon variable `rate_payloads_consumed` is close to 166 (actually I get closer values with this new version) and there are no errors, everything else seems to be ok.
CPU usage is certainly lower, I'm getting between 20% and 25% improvements (for 1 - 5 links, it's less as the load increases since less time is spent in the rate limiter). For example, running with 5 links:
**Current version**
![Current version](https://user-images.githubusercontent.com/22276694/152748596-9d72d00c-0758-4e3d-a353-e81ce4b573ec.png)
**Version in this PR**
![Version in this PR](https://user-images.githubusercontent.com/22276694/152748611-e1137abc-12f5-4f1c-8b45-6cc65d99bc27.png)

