### PR TITLE
One line fix for rate limiter

### DIFF
--- a/include/readoutlibs/utils/RateLimiter.hpp
+++ b/include/readoutlibs/utils/RateLimiter.hpp
@@ -66,6 +66,7 @@ public:
 
   void limit()
   {
+    m_now = gettime();
     if (m_now > m_deadline + m_max_overshoot) {
       m_deadline = m_now + m_period.load();
     } else {

--- a/include/readoutlibs/utils/RateLimiter.hpp
+++ b/include/readoutlibs/utils/RateLimiter.hpp
@@ -25,6 +25,12 @@ namespace readoutlibs {
  *    limiter.limit();
  *  }
  */
+/** NOTES:
+    This rate limiter is a simple implementation that is intended to be
+    used for fast tasks, i.e. tasks that take less or much less time than the
+    time intervals (1 / rate) that the RateLimiter is operating with. It doesn't
+    work correctly if the tasks take longer than 1 / rate.
+ */
 class RateLimiter
 {
 public:


### PR DESCRIPTION
After a bit of discussion with Kurt one line that he proposed is added to correctly set the value of `m_now`, as continuation of #5. The conclusion was that adding this line is correct but we won't be able to see it since it only fixes the first cycle in the rate limiter loop, while all the other cycles but the first one were working fine. We don't see it because if we average over thousands or millions of cycles, the rate limiter working fine or not for the first cycle doesn't change the results. I added a comment pointing out that this rate limiter only works correctly for _fast_ tasks.