### PR TITLE
Modifications to latency buffer/request handling for DS 

### DIFF
--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -52,6 +52,13 @@ using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;
 namespace dunedaq {
 namespace readoutlibs {
 
+template<class T>
+uint64_t
+get_frame_iterator_timestamp(T iter)
+{
+  return iter->get_timestamp();
+}
+
 template<class ReadoutType, class LatencyBufferType>
 class DefaultRequestHandlerModel : public RequestHandlerConcept<ReadoutType, LatencyBufferType>
 {
@@ -562,7 +569,7 @@ protected:
                   end_win_ts) {
               // We don't need the whole aggregated object (e.g.: superchunk)
               for (auto frame_iter = element->begin(); frame_iter != element->end(); frame_iter++) {
-                if ((*frame_iter).get_timestamp() >= start_win_ts && (*frame_iter).get_timestamp() < end_win_ts) {
+                if (get_frame_iterator_timestamp(frame_iter) >= start_win_ts && get_frame_iterator_timestamp(frame_iter) < end_win_ts) {
                   frag_pieces.emplace_back(
                     std::make_pair<void*, size_t>(static_cast<void*>(&(*frame_iter)), element->get_frame_size()));
                 }

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -15,7 +15,7 @@
 #include "readoutlibs/utils/ReusableThread.hpp"
 
 #include "readoutlibs/readoutconfig/Nljs.hpp"
-#include "readoutlibs/readoutinfo/InfoStructs.hpp"
+#include "readoutlibs/readoutinfo/InfoNljs.hpp"
 
 #include "appfwk/Issues.hpp"
 #include "daqdataformats/Fragment.hpp"

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -52,6 +52,16 @@ using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;
 namespace dunedaq {
 namespace readoutlibs {
 
+// This function takes the type returned by the begin() and end()
+// functions in a ReadoutType object and returns the timestamp that
+// should be used to determine whether the item pointed to by the
+// iterator is within the readout window. The "frame" type
+// ReadoutTypes all have a get_timestamp() function on the type
+// pointed to by the iterator (eg, WIBFrame), so we make this
+// "default" function return that. For other types, eg, those coming
+// from DS, there isn't a get_timestamp() function, so a different
+// template specialization is used in the appropriate package (eg,
+// trigger)
 template<class T>
 uint64_t
 get_frame_iterator_timestamp(T iter)


### PR DESCRIPTION
This PR shows one option of how to make a change needed to be able to use the latency buffer/request handling for DS objects (TriggerPrimitive, TriggerActivity, TriggerCandidate). This is for discussion, since there are probably other ways to implement it.

The types previously stored in the latency buffer were all "frame"-type objects, with an overall "superchunk" containing one or more frames. The inner frames all have a `get_timestamp()` method that returns the frame's timestamp. DS objects don't have such a function, and it doesn't make sense to add one. So this PR adds a template function `get_frame_iterator_timestamp(T iter)` which returns the timestamp for a pointer to a frame. For "frame" type objects, it just returns `iter->get_timestamp()`, and for DS objects, the template can be specialized, as shown here:

https://github.com/DUNE-DAQ/trigger/blob/e6e392d2c434f945000b2d3da772b98c3865a465/plugins/TPBuffer.hpp#L135