### PR TITLE
Firmware TP publishing for dunedaq-v3.0.0

### DIFF
--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -70,6 +70,8 @@ local readoutconfig = {
                             doc="Channel map felix file for software TPG. If empty string, look in $READOUT_SHARE"),
             s.field("enable_software_tpg", self.choice, false,
                             doc="Enable software TPG"),
+            s.field("enable_firmware_tpg", self.choice, false,
+                            doc="Enable firmware TPG"),
             s.field("channel_map_name", self.string, default="None",
                             doc="Name of channel map"),
             s.field("emulator_mode", self.choice, false,


### PR DESCRIPTION
This PR is part of series of branches addressing the firmware TPG integration (fwTPG), targeting dunedaq-v3.0.0.
In this package we add an option to enable fwTPG via the configuration (enable_firmware_tpg).
It is related to PR https://github.com/DUNE-DAQ/fdreadoutlibs/pull/17 and https://github.com/DUNE-DAQ/daq-deliverables/issues/20. 