### PR TITLE
Don't send TimeSyncs whose timestamp is the same as the previous one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(readoutlibs VERSION 1.1.0)
+project(readoutlibs VERSION 1.1.1)
 
 find_package(daq-cmake REQUIRED)
 


### PR DESCRIPTION
When the run stops, the "last DAQ time" used for the TimeSyncs stops
updating, but the TimeSync thread is still running, and sending out
new TimeSyncs with the same, stale, timestamp. So don't do that.

This fixes #30 