### PR TITLE
Added information to TRACE messages associated with DataRequests

### DIFF
--- a/include/readoutlibs/ReadoutIssues.hpp
+++ b/include/readoutlibs/ReadoutIssues.hpp
@@ -163,7 +163,7 @@ ERS_DECLARE_ISSUE(readoutlibs,
                   VerboseRequestTimedOut,
                   "GeoID[" << geoid << "] Request timed out for trig/seq_num " << trignum << "." << seqnum
                            << ", run_num " << runnum << ", window begin/end " << window_begin << "/" << window_end
-                           << ", data_destination " << dest,
+                           << ", data_destination: " << dest,
                   ((daqdataformats::GeoID)geoid)((daqdataformats::trigger_number_t)trignum)((daqdataformats::sequence_number_t)seqnum)((daqdataformats::run_number_t)runnum)((daqdataformats::timestamp_t)window_begin)((daqdataformats::timestamp_t)window_end)((std::string)dest))
 
 ERS_DECLARE_ISSUE(readoutlibs,

--- a/include/readoutlibs/ReadoutIssues.hpp
+++ b/include/readoutlibs/ReadoutIssues.hpp
@@ -9,6 +9,7 @@
 #define READOUTLIBS_INCLUDE_READOUTLIBS_READOUTISSUES_HPP_
 
 #include "daqdataformats/GeoID.hpp"
+#include "daqdataformats/Types.hpp"
 
 #include <ers/Issue.hpp>
 
@@ -157,6 +158,13 @@ ERS_DECLARE_ISSUE(readoutlibs,
                   RequestTimedOut,
                   "GeoID[" << geoid << "] Request timed out",
                   ((daqdataformats::GeoID)geoid))
+
+ERS_DECLARE_ISSUE(readoutlibs,
+                  VerboseRequestTimedOut,
+                  "GeoID[" << geoid << "] Request timed out for trig/seq_num " << trignum << "." << seqnum
+                           << ", run_num " << runnum << ", window begin/end " << window_begin << "/" << window_end
+                           << ", data_destination " << dest,
+                  ((daqdataformats::GeoID)geoid)((daqdataformats::trigger_number_t)trignum)((daqdataformats::sequence_number_t)seqnum)((daqdataformats::run_number_t)runnum)((daqdataformats::timestamp_t)window_begin)((daqdataformats::timestamp_t)window_end)((std::string)dest))
 
 ERS_DECLARE_ISSUE(readoutlibs,
                   EndOfRunEmptyFragment,

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -300,8 +300,9 @@ public:
       m_cv.notify_all();
       if (result.result_code == ResultCode::kFound || result.result_code == ResultCode::kNotFound) {
         try { // Send to fragment connection
-          TLOG_DEBUG(TLVL_QUEUE_PUSH) << "Sending fragment with trigger_number "
-                                      << result.fragment->get_trigger_number() << ", run number "
+          TLOG_DEBUG(TLVL_QUEUE_PUSH) << "Sending fragment with trigger/sequence_number "
+                                      << result.fragment->get_trigger_number() << "."
+                                      << result.fragment->get_sequence_number() << ", run number "
                                       << result.fragment->get_run_number() << ", and GeoID "
                                       << result.fragment->get_element_id();
 	  get_iom_sender<std::unique_ptr<daqdataformats::Fragment>>(datarequest.data_destination)->send(std::move(result.fragment), std::chrono::milliseconds(10));
@@ -485,7 +486,13 @@ protected:
           } else if (m_waiting_requests[i].retry_count >= m_retry_count) {
             issue_request(m_waiting_requests[i].request, true);
 
-            ers::warning(dunedaq::readoutlibs::RequestTimedOut(ERS_HERE, m_geoid));
+            ers::warning(dunedaq::readoutlibs::VerboseRequestTimedOut(ERS_HERE, m_geoid,
+                                                                      m_waiting_requests[i].request.trigger_number,
+                                                                      m_waiting_requests[i].request.sequence_number,
+                                                                      m_waiting_requests[i].request.run_number,
+                                                                      m_waiting_requests[i].request.request_information.window_begin,
+                                                                      m_waiting_requests[i].request.request_information.window_end,
+                                                                      m_waiting_requests[i].request.data_destination));
             m_num_requests_bad++;
             m_num_requests_timed_out++;
 

--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -380,7 +380,7 @@ private:
                                << ", GeoID: " << data_request.request_information.component
                                << ", window begin/end " << data_request.request_information.window_begin
                                << "/" << data_request.request_information.window_end
-                               << ", dest " << data_request.data_destination;
+                               << ", dest: " << data_request.data_destination;
     m_request_handler_impl->issue_request(data_request, false);
     ++m_num_requests;
     ++m_sum_requests;

--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -373,12 +373,17 @@ private:
        ers::error(RequestGeoIDMismatch(ERS_HERE, m_geoid, data_request.request_information.component));
        return;
     }
+    TLOG_DEBUG(TLVL_QUEUE_POP) << "Received DataRequest for trig/seq_number "
+                               << data_request.trigger_number << "." << data_request.sequence_number
+                               << ", runno " << data_request.run_number
+                               << ", trig timestamp " << data_request.trigger_timestamp
+                               << ", GeoID: " << data_request.request_information.component
+                               << ", window begin/end " << data_request.request_information.window_begin
+                               << "/" << data_request.request_information.window_end
+                               << ", dest " << data_request.data_destination;
     m_request_handler_impl->issue_request(data_request, false);
     ++m_num_requests;
     ++m_sum_requests;
-    TLOG_DEBUG(TLVL_QUEUE_POP) << "Received DataRequest for trigger_number " << data_request.trigger_number
-                               << ", run number " << data_request.run_number << " (APA number "
-                               << m_geoid.region_id << ", link number " << m_geoid.element_id << ")";
   }
 
   // Constuctor params


### PR DESCRIPTION
I found this additional TRACE information helpful when debugging the receipt of DataRequests and subsequent sending of fragments.  These changes are not intended for v3.0.0, so I will set the TargetRelease for this PR to v3.1.0.

For the change to the ERS_WARNING in DefaultRequestHandlerModel, I didn't know if we have a guideline on how many arguments we can/should provide to an ERS Issue.  I could change the code included here to have a less verbose warning message and an accompanying message of a different severity, if we want to keep warning messages terse.