### PR TITLE
Capture an argument by value, not reference

### DIFF
--- a/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -187,7 +187,7 @@ void
 DefaultRequestHandlerModel<RDT, LBT>::issue_request(dfmessages::DataRequest datarequest,
                                                     bool send_partial_fragment_if_not_yet)
 {
-  boost::asio::post(*m_request_handler_thread_pool, [&, datarequest]() { // start a thread from pool
+  boost::asio::post(*m_request_handler_thread_pool, [&, send_partial_fragment_if_not_yet, datarequest]() { // start a thread from pool
     auto t_req_begin = std::chrono::high_resolution_clock::now();
     {
       std::unique_lock<std::mutex> lock(m_cv_mutex);


### PR DESCRIPTION
The `send_partial_fragment_if_not_yet` argument to `DefaultRequestHandlerModel::issue_request` needs to be captured by value, not reference, when creating the thread that is put on the thread pool. Otherwise behaviour is non-deterministic (and probably undefined)