### PR TITLE
Data request updates for TC

### DIFF
--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -252,7 +252,7 @@ protected:
   std::string m_output_file;
   size_t m_stream_buffer_size = 0;
   bool m_recording_configured = false;
-
+  bool m_warn_on_timeout = true; // Whether to warn when a request times out
   // Stats
   std::atomic<int> m_pop_counter;
   std::atomic<int> m_num_buffer_cleanups{ 0 };

--- a/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -489,10 +489,19 @@ DefaultRequestHandlerModel<RDT, LBT>::data_request(dfmessages::DataRequest dr,
         // We've been asked to send the partial fragment if we don't
         // have an object past the end of the window, so fill the
         // fragment with what we have so far
-        TLOG() << "Returning partial fragment for trig/seq number " << dr.trigger_number << "." << dr.sequence_number
-          << " with TS " << dr.trigger_timestamp 
-          << ". Component " << dr.request_information.component 
-          << " with type " << daqdataformats::fragment_type_to_string(daqdataformats::FragmentType(frag_header.fragment_type));
+        if (m_warn_on_timeout) {
+          TLOG()
+            << "Returning partial fragment for trig/seq number " << dr.trigger_number << "." << dr.sequence_number
+            << " with TS " << dr.trigger_timestamp 
+            << ". Component " << dr.request_information.component 
+            << " with type " << daqdataformats::fragment_type_to_string(daqdataformats::FragmentType(frag_header.fragment_type));
+        } else {
+          TLOG_DEBUG(TLVL_WORK_STEPS)
+            << "Returning partial fragment for trig/seq number " << dr.trigger_number << "." << dr.sequence_number
+            << " with TS " << dr.trigger_timestamp 
+            << ". Component " << dr.request_information.component 
+            << " with type " << daqdataformats::fragment_type_to_string(daqdataformats::FragmentType(frag_header.fragment_type));
+        }
         frag_header.error_bits |= (0x1 << static_cast<size_t>(daqdataformats::FragmentErrorBits::kIncomplete));
         frag_pieces = get_fragment_pieces(start_win_ts, end_win_ts, rres);
       } else {

--- a/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -18,6 +18,7 @@ DefaultRequestHandlerModel<RDT, LBT>::conf(const nlohmann::json& args)
   m_geoid.region_id = conf.region_id;
   m_geoid.system_type = RDT::system_type;
   m_stream_buffer_size = conf.stream_buffer_size;
+  m_warn_on_timeout = conf.warn_on_timeout;
   // if (m_configured) {
   //  ers::error(ConfigurationError(ERS_HERE, "This object is already configured!"));
   if (m_pop_limit_pct < 0.0f || m_pop_limit_pct > 1.0f || m_pop_size_pct < 0.0f || m_pop_size_pct > 1.0f) {
@@ -369,13 +370,15 @@ DefaultRequestHandlerModel<RDT, LBT>::check_waiting_requests()
         } else if (m_waiting_requests[i].retry_count >= m_retry_count) {
           issue_request(m_waiting_requests[i].request, true);
 
-          ers::warning(dunedaq::readoutlibs::VerboseRequestTimedOut(ERS_HERE, m_geoid,
-             m_waiting_requests[i].request.trigger_number,
-             m_waiting_requests[i].request.sequence_number,
-             m_waiting_requests[i].request.run_number,
-             m_waiting_requests[i].request.request_information.window_begin,
-             m_waiting_requests[i].request.request_information.window_end,
-             m_waiting_requests[i].request.data_destination));
+          if (m_warn_on_timeout) {
+            ers::warning(dunedaq::readoutlibs::VerboseRequestTimedOut(ERS_HERE, m_geoid,
+                                                                      m_waiting_requests[i].request.trigger_number,
+                                                                      m_waiting_requests[i].request.sequence_number,
+                                                                      m_waiting_requests[i].request.run_number,
+                                                                      m_waiting_requests[i].request.request_information.window_begin,
+                                                                      m_waiting_requests[i].request.request_information.window_end,
+                                                                      m_waiting_requests[i].request.data_destination));
+          }
 
           m_num_requests_bad++;
           m_num_requests_timed_out++;

--- a/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
+++ b/include/readoutlibs/models/detail/DefaultRequestHandlerModel.hxx
@@ -187,7 +187,7 @@ void
 DefaultRequestHandlerModel<RDT, LBT>::issue_request(dfmessages::DataRequest datarequest,
                                                     bool send_partial_fragment_if_not_yet)
 {
-  boost::asio::post(*m_request_handler_thread_pool, [&, datarequest]() { // start a thread from pool
+  boost::asio::post(*m_request_handler_thread_pool, [&, send_partial_fragment_if_not_yet, datarequest]() { // start a thread from pool
     auto t_req_begin = std::chrono::high_resolution_clock::now();
     {
       std::unique_lock<std::mutex> lock(m_cv_mutex);

--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -114,7 +114,9 @@ local readoutconfig = {
             s.field("region_id", self.region_id, 0,
                             doc="The region id of this link"),
             s.field("element_id", self.element_id, 0,
-                            doc="The element id of this link")],
+                            doc="The element id of this link"),
+            s.field("warn_on_timeout", self.choice, true,
+                            doc="Whether to emit a warning when a request times out")],
             doc="Request Handler Config"),
 
     readoutmodelconf : s.record("ReadoutModelConf", [


### PR DESCRIPTION
This PR contains two changes needed to implement the behaviour requested in https://github.com/DUNE-DAQ/trigger/issues/134 . The first is a bug fix to correctly capture a variable by value instead of reference in `DefaultRequestHandlerModel`. The second is adding a `warn_on_timeout` option to the request handler config. The motivation is that requests on the TC buffer will often time out because the rate of TCs may be low. So it doesn't make sense to emit a warning when TC data requests time out.