### PR TITLE
Convert the data request timeout parameter from a retry count to a time interval

### DIFF
--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -109,14 +109,14 @@ public:
   // A struct that combines a data request, with the number of times it was issued internally
   struct RequestElement
   {
-    RequestElement(dfmessages::DataRequest data_request,
-                   size_t retries)
+    RequestElement(const dfmessages::DataRequest& data_request,
+                   const std::chrono::time_point<std::chrono::high_resolution_clock>& tp_value)
       : request(data_request)
-      , retry_count(retries)
+      , start_time(tp_value)
     {}
 
     dfmessages::DataRequest request;
-    size_t retry_count;
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
   };
 
   // Default init mechanism (no-op impl)
@@ -245,7 +245,7 @@ protected:
   float m_pop_limit_pct;     // buffer occupancy percentage to issue a pop request
   float m_pop_size_pct;      // buffer percentage to pop
   unsigned m_pop_limit_size; // pop_limit_pct * buffer_capacity
-  size_t m_retry_count;
+  int m_request_timeout_ms;
   size_t m_buffer_capacity;
   daqdataformats::GeoID m_geoid;
   static const constexpr uint32_t m_min_delay_us = 30000; // NOLINT(build/unsigned)

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -245,7 +245,6 @@ protected:
   float m_pop_limit_pct;     // buffer occupancy percentage to issue a pop request
   float m_pop_size_pct;      // buffer percentage to pop
   unsigned m_pop_limit_size; // pop_limit_pct * buffer_capacity
-  int m_request_timeout_ms;
   size_t m_buffer_capacity;
   daqdataformats::GeoID m_geoid;
   static const constexpr uint32_t m_min_delay_us = 30000; // NOLINT(build/unsigned)
@@ -273,6 +272,9 @@ protected:
   // Request response time log (kept for debugging if needed)
   // std::deque<std::pair<int, int>> m_response_time_log;
   // std::mutex m_response_time_log_lock;
+
+private:
+    int m_request_timeout_ms;
 };
 
 } // namespace readoutlibs

--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -91,8 +91,8 @@ local readoutconfig = {
     requesthandlerconf : s.record("RequestHandlerConf", [
             s.field("num_request_handling_threads", self.count, 4,
                             doc="Number of threads to use for data request handling"),
-            s.field("retry_count", self.count, 100,
-                            doc="Number of times to recheck a request before sending an empty fragment"),
+            s.field("request_timeout_ms", self.count, 1000,
+                            doc="Timeout for checking for valid data in response to a request before sending an empty fragment"),
             s.field("output_file", self.file_name, "output.out",
                             doc="Name of the output file to write to"),
             s.field("stream_buffer_size", self.size, 8388608,


### PR DESCRIPTION
As the title describes, the purpose of this PR is to convert the use of a retry count for determining when a data request times out to the use of a time interval.  

This change is part of a larger effort to provide sensible, correlated timeouts in several parts of the system.

This PR is coupled with one in the daqconf repo, and the changes in both repos will need to be merged to the respective _develop_ branches at the same time.

