### PR TITLE
Adding FW TP stitching configuration option

### DIFF
--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -72,6 +72,8 @@ local readoutconfig = {
                             doc="Enable software TPG"),
             s.field("enable_firmware_tpg", self.choice, false,
                             doc="Enable firmware TPG"),
+            s.field("fwtp_stitch_constant", self.size, 2000,
+                            doc="Number of ticks between WIB-to-TP packets"),
             s.field("channel_map_name", self.string, default="None",
                             doc="Name of channel map"),
             s.field("emulator_mode", self.choice, false,


### PR DESCRIPTION
This PR addresses https://github.com/DUNE-DAQ/fdreadoutlibs/issues/27
The firmware TP stitching uses the number of ticks between the packed WIB frames (64 frames in a packet). 
This number was 1600 for WIB1 and 2000 for WIB2. This is now made  a configurable parameter.
Each so called WIB-to-TP packet consists of 64 WIB frames, with consecutive timestamps, packed in a format suitable for the firmware TPG. 
It is related to https://github.com/DUNE-DAQ/fdreadoutlibs/pull/35
