### PR TITLE
Make the raw TP frame unpacking configurable

### DIFF
--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -74,6 +74,8 @@ local readoutconfig = {
                             doc="Enable firmware TPG"),
             s.field("fwtp_stitch_constant", self.size, 2000,
                             doc="Number of ticks between WIB-to-TP packets"),
+            s.field("fwtp_format_version", self.size, 1,
+                            doc="Format version of raw TP frames from firmware TPG"),
             s.field("channel_map_name", self.string, default="None",
                             doc="Name of channel map"),
             s.field("emulator_mode", self.choice, false,


### PR DESCRIPTION
This PR adds the option to configure the unpacking of the raw TP frames according to the firmware TPG format. Currently 
we have two fwTGP format versions, which we call "old" and "new", or alternatively, we can refer to them as "v1" and "v2".
This feature involves changes in the following packages (where the relevant PRs are made as well):
fdreadoutlibs
readoutlibs (here)
readoutmodules  
https://github.com/DUNE-DAQ/fdreadoutlibs/pull/46
https://github.com/DUNE-DAQ/readoutlibs/pull/49
https://github.com/DUNE-DAQ/readoutmodules/pull/28

The new TP format was implemented in firmware as a response to a request we made from the readout side, and it makes the unpacking more straightforward in software, because the TP header explicitly contains the number of hits. 

This corresponds to issue: https://github.com/DUNE-DAQ/fdreadoutlibs/issues/26