### PR TITLE
Make dtors of *Concept classes virtual, to quiet a compiler warning

### DIFF
--- a/include/readoutlibs/concepts/LatencyBufferConcept.hpp
+++ b/include/readoutlibs/concepts/LatencyBufferConcept.hpp
@@ -27,6 +27,9 @@ class LatencyBufferConcept
 
 public:
   LatencyBufferConcept() {}
+
+  virtual ~LatencyBufferConcept() {}
+  
   LatencyBufferConcept(const LatencyBufferConcept&) = delete; ///< LatencyBufferConcept is not copy-constructible
   LatencyBufferConcept& operator=(const LatencyBufferConcept&) =
     delete;                                                         ///< LatencyBufferConcept is not copy-assginable

--- a/include/readoutlibs/concepts/RawDataProcessorConcept.hpp
+++ b/include/readoutlibs/concepts/RawDataProcessorConcept.hpp
@@ -21,7 +21,8 @@ class RawDataProcessorConcept
 {
 public:
   RawDataProcessorConcept() {}
-
+  virtual ~RawDataProcessorConcept() {}
+  
   RawDataProcessorConcept(const RawDataProcessorConcept&) =
     delete; ///< RawDataProcessorConcept is not copy-constructible
   RawDataProcessorConcept& operator=(const RawDataProcessorConcept&) =

--- a/include/readoutlibs/concepts/ReadoutConcept.hpp
+++ b/include/readoutlibs/concepts/ReadoutConcept.hpp
@@ -18,7 +18,7 @@ class ReadoutConcept
 {
 public:
   ReadoutConcept() {}
-  ~ReadoutConcept() {}
+  virtual ~ReadoutConcept() {}
   ReadoutConcept(const ReadoutConcept&) = delete;            ///< ReadoutConcept is not copy-constructible
   ReadoutConcept& operator=(const ReadoutConcept&) = delete; ///< ReadoutConcept is not copy-assginable
   ReadoutConcept(ReadoutConcept&&) = delete;                 ///< ReadoutConcept is not move-constructible

--- a/include/readoutlibs/concepts/RecorderConcept.hpp
+++ b/include/readoutlibs/concepts/RecorderConcept.hpp
@@ -29,7 +29,7 @@ class RecorderConcept
 {
 public:
   RecorderConcept() {}
-  ~RecorderConcept() {}
+  virtual ~RecorderConcept() {}
   RecorderConcept(const RecorderConcept&) = delete;
   RecorderConcept& operator=(const RecorderConcept&) = delete;
   RecorderConcept(RecorderConcept&&) = delete;

--- a/include/readoutlibs/concepts/RequestHandlerConcept.hpp
+++ b/include/readoutlibs/concepts/RequestHandlerConcept.hpp
@@ -27,6 +27,9 @@ class RequestHandlerConcept
 
 public:
   RequestHandlerConcept() {}
+
+  virtual ~RequestHandlerConcept() {}
+  
   RequestHandlerConcept(const RequestHandlerConcept&) = delete; ///< RequestHandlerConcept is not copy-constructible
   RequestHandlerConcept& operator=(const RequestHandlerConcept&) =
     delete;                                                ///< RequestHandlerConcept is not copy-assginable

--- a/include/readoutlibs/concepts/SourceEmulatorConcept.hpp
+++ b/include/readoutlibs/concepts/SourceEmulatorConcept.hpp
@@ -25,7 +25,7 @@ class SourceEmulatorConcept
 public:
   SourceEmulatorConcept() {}
 
-  ~SourceEmulatorConcept() {}
+  virtual ~SourceEmulatorConcept() {}
   SourceEmulatorConcept(const SourceEmulatorConcept&) = delete; ///< SourceEmulatorConcept is not copy-constructible
   SourceEmulatorConcept& operator=(const SourceEmulatorConcept&) =
     delete;                                                ///< SourceEmulatorConcept is not copy-assginable


### PR DESCRIPTION
This PR makes the destructors of the *Concept classes virtual, so that warnings from `-Wnon-virtual-dtor` are silenced