### PR TITLE
Make the raw TP frame unpacking configurable

### DIFF
--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -70,7 +70,7 @@ local readoutconfig = {
                             doc="Enable software TPG"),
             s.field("enable_firmware_tpg", self.choice, false,
                             doc="Enable firmware TPG"),
-            s.field("fwtp_stitch_constant", self.size, 2000,
+            s.field("fwtp_stitch_constant", self.size, 2048,
                             doc="Number of ticks between WIB-to-TP packets"),
             s.field("fwtp_format_version", self.size, 1,
                             doc="Format version of raw TP frames from firmware TPG"),


### PR DESCRIPTION
This PR is based on https://github.com/DUNE-DAQ/readoutlibs/pull/49
It is indeded to merge to develop for dunedaq-v3.2.0

Here the interval between consecutive WIB-to-TP frames is changed fto 2048 from 2000 time units. 
The old value of 2000 when divided by 64 ticks gives 31.25 which not integer. We believe the correct value is 2048.  