### PR TITLE
Candidate changes to help with missing HSI fragments at the start of …

### DIFF
--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -142,7 +142,7 @@ public:
 
   // Implementation of default request handling. (boost::asio post to a thread pool)
   void issue_request(dfmessages::DataRequest datarequest,
-                     bool send_partial_fragment_if_not_yet) override;
+                     bool send_partial_fragment_if_available) override;
 
   // Opmon get_info implementation
   void get_info(opmonlib::InfoCollector& ci, int /*level*/) override;
@@ -203,7 +203,7 @@ protected:
 
   // Override data_request functionality
   RequestResult data_request(dfmessages::DataRequest dr, 
-                             bool send_partial_fragment_if_not_yet) override;
+                             bool send_partial_fragment_if_available) override;
 
   // Data access (LB)
   std::unique_ptr<LatencyBufferType>& m_latency_buffer;

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -254,6 +254,7 @@ protected:
   size_t m_stream_buffer_size = 0;
   bool m_recording_configured = false;
   bool m_warn_on_timeout = true; // Whether to warn when a request times out
+  bool m_warn_about_empty_buffer = true; // Whether to warn about an empty buffer when processing a request
   // Stats
   std::atomic<int> m_pop_counter;
   std::atomic<int> m_num_buffer_cleanups{ 0 };

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -110,13 +110,16 @@ public:
   struct RequestElement
   {
     RequestElement(const dfmessages::DataRequest& data_request,
-                   const std::chrono::time_point<std::chrono::high_resolution_clock>& tp_value)
+                   const std::chrono::time_point<std::chrono::high_resolution_clock>& tp_value,
+                   bool partial_fragment_flag = false)
       : request(data_request)
       , start_time(tp_value)
+      , send_partial_fragment_if_available(partial_fragment_flag)
     {}
 
     dfmessages::DataRequest request;
     std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
+    bool send_partial_fragment_if_available;
   };
 
   // Default init mechanism (no-op impl)

--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -78,6 +78,7 @@ public:
     : m_run_marker(run_marker)
     , m_fake_trigger(false)
     , m_current_fake_trigger_id(0)
+    , m_send_partial_fragment_if_available(false)
     , m_consumer_thread(0)
     , m_raw_receiver_timeout_ms(0)
     , m_raw_data_receiver(nullptr)
@@ -139,6 +140,7 @@ private:
   int m_current_fake_trigger_id;
   daqdataformats::SourceID m_sourceid;
   daqdataformats::run_number_t m_run_number;
+  bool m_send_partial_fragment_if_available;
  
   // STATS
   std::atomic<int> m_num_payloads{ 0 };

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -79,6 +79,8 @@ ReadoutModel<RDT, RHT, LBT, RPT>::conf(const nlohmann::json& args)
   m_timesync_connection_name = conf.timesync_connection_name;
   m_timesync_topic_name = conf.timesync_topic_name;
 
+  m_send_partial_fragment_if_available = conf.send_partial_fragment_if_available;
+
   // Configure implementations:
   m_raw_processor_impl->conf(args);
   // Configure the latency buffer before the request handler so the request handler can check for alignment
@@ -317,7 +319,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::dispatch_requests(dfmessages::DataRequest& dat
     << ", window begin/end " << data_request.request_information.window_begin
     << "/" << data_request.request_information.window_end
     << ", dest: " << data_request.data_destination;
-  m_request_handler_impl->issue_request(data_request, false);
+  m_request_handler_impl->issue_request(data_request, m_send_partial_fragment_if_available);
   ++m_num_requests;
   ++m_sum_requests;
 }

--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -116,7 +116,9 @@ local readoutconfig = {
             s.field("det_id", self.det_id, 1,
                             doc="The det id of data carried by this link"),
             s.field("warn_on_timeout", self.choice, true,
-                            doc="Whether to emit a warning when a request times out")],
+                            doc="Whether to emit a warning when a request times out"),
+            s.field("warn_about_empty_buffer", self.choice, true,
+                            doc="Whether to emit a warning when there is no data in the buffer when a request is processed")],
             doc="Request Handler Config"),
 
     readoutmodelconf : s.record("ReadoutModelConf", [

--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -127,7 +127,9 @@ local readoutconfig = {
             s.field("source_id", self.source_id, 0,
                             doc="The source id of this link"),
             s.field("timesync_connection_name", self.netmgr_name, "", doc="Connection name for sending timesyncs"),
-            s.field("timesync_topic_name", self.netmgr_name, "Timesync", doc="Topic for sending timesyncs")
+            s.field("timesync_topic_name", self.netmgr_name, "Timesync", doc="Topic for sending timesyncs"),
+            s.field("send_partial_fragment_if_available", self.choice, false,
+                            doc="Whether to send a partial fragment if one is available")
     ], doc="Readout Model Config"),
 
     conf: s.record("Conf", [


### PR DESCRIPTION
…a run; the proposed fix is to allow the start of the readout window to be earlier than the oldest data in the buffer if the send_partial_fragment_if_available flag is set to true.