### PR TITLE
use the get_num_frames method of data types instead of hardcoding 12...

### DIFF
--- a/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
@@ -160,7 +160,7 @@ SourceEmulatorModel<ReadoutType>::run_produce()
       ++m_packet_count_tot;
     }
 
-    timestamp += m_time_tick_diff * 12;
+    timestamp += m_time_tick_diff * rptr->get_num_frames();
 
     m_rate_limiter->limit();
   }


### PR DESCRIPTION
Part of Daq-deliverable issue on WIB ethernet consolidation:
https://github.com/DUNE-DAQ/daq-deliverables/issues/64
