### PR TITLE
Removed the ReadoutModel conf-time timesync_connection_name parameter

### DIFF
--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -21,6 +21,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::init(const nlohmann::json& args)
       } else if (cr.name == "timesync_output") {
   	    TLOG() << "Create timesync sender";
   	    m_timesync_sender = get_iom_sender<dfmessages::TimeSync>(cr.uid);
+            m_timesync_connection_name = cr.uid;
       }
     }
     //iomanager::ConnectionRef raw_input_ref = iomanager::ConnectionRef{ "input", "raw_input", iomanager::Direction::kInput };
@@ -77,8 +78,6 @@ ReadoutModel<RDT, RHT, LBT, RPT>::conf(const nlohmann::json& args)
 
   m_sourceid.id = conf.source_id;
   m_sourceid.subsystem = RDT::subsystem;
-
-  m_timesync_connection_name = conf.timesync_connection_name;
 
   m_send_partial_fragment_if_available = conf.send_partial_fragment_if_available;
 

--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -36,8 +36,6 @@ local readoutconfig = {
     string : s.string("String", moo.re.ident,
                       doc="A string field"),
 
-    netmgr_name : s.string("NetworkManagerName", doc="Connection or topic name to be used with NetworkManager"),
-
     latencybufferconf : s.record("LatencyBufferConf", [
             s.field("latency_buffer_size", self.size, 100000,
                             doc="Size of latency buffer"),
@@ -135,7 +133,6 @@ local readoutconfig = {
                             doc="Timeout for source queue"),
             s.field("source_id", self.source_id, 0,
                             doc="The source id of this link"),
-            s.field("timesync_connection_name", self.netmgr_name, "", doc="Connection name for sending timesyncs"),
             s.field("send_partial_fragment_if_available", self.choice, false,
                             doc="Whether to send a partial fragment if one is available")
     ], doc="Readout Model Config"),


### PR DESCRIPTION
… because A) it can be determined at INIT time, and B) because the value that it is being set to  (in daqconf) was wrong.

The changes in this repo were to move the data member assignment to the init() method and remove the conf-time parameter from the associated schema.

I noticed these problems when working on improving the handling of connection information as part of the ConnectivityService consolidation.

This PR is tied to a corresponding PR in the daqconf repo.