### PR TITLE
Added config param to SourceEmulatorModel to allow the data t0 to be set to "now"

### DIFF
--- a/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
@@ -124,8 +124,7 @@ SourceEmulatorModel<ReadoutType>::run_produce()
     auto time_now = std::chrono::system_clock::now().time_since_epoch();
     uint64_t current_time = // NOLINT (build/unsigned)
       std::chrono::duration_cast<std::chrono::microseconds>(time_now).count();
-    uint64_t m_clock_frequency = 62500000; // NOLINT (build/unsigned)
-    ts_0 = (m_clock_frequency / 100000) * current_time;
+    ts_0 = (m_conf.clock_speed_hz / 100000) * current_time;
     ts_0 /= 10;
   }
   TLOG_DEBUG(TLVL_BOOKKEEPING) << "Using first timestamp: " << ts_0;

--- a/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
@@ -116,8 +116,19 @@ SourceEmulatorModel<ReadoutType>::run_produce()
   auto rptr = reinterpret_cast<ReadoutType*>(source.data()); // NOLINT
 
   // set the initial timestamp to a configured value, otherwise just use the timestamp from the header
-  uint64_t ts_0 = (m_conf.set_t0_to >= 0) ? m_conf.set_t0_to : rptr->get_first_timestamp(); // NOLINT(build/unsigned)
-  TLOG_DEBUG(TLVL_BOOKKEEPING) << "First timestamp in the source file: " << ts_0;
+  uint64_t ts_0 = rptr->get_first_timestamp(); // NOLINT(build/unsigned)
+  if (m_conf.set_t0_to >= 0) {
+    ts_0 = m_conf.set_t0_to;
+  }
+  else if (m_conf.use_now_as_first_data_time) {
+    auto time_now = std::chrono::system_clock::now().time_since_epoch();
+    uint64_t current_time = // NOLINT (build/unsigned)
+      std::chrono::duration_cast<std::chrono::microseconds>(time_now).count();
+    uint64_t m_clock_frequency = 62500000; // NOLINT (build/unsigned)
+    ts_0 = (m_clock_frequency / 100000) * current_time;
+    ts_0 /= 10;
+  }
+  TLOG_DEBUG(TLVL_BOOKKEEPING) << "Using first timestamp: " << ts_0;
   uint64_t timestamp = ts_0; // NOLINT(build/unsigned)
   int dropout_index = 0;
 

--- a/schema/readoutlibs/sourceemulatorconfig.jsonnet
+++ b/schema/readoutlibs/sourceemulatorconfig.jsonnet
@@ -64,7 +64,10 @@ local sourceemulatorconfig = {
 
         s.field("queue_timeout_ms", self.uint4, 2000,
                 doc="Queue timeout in milliseconds"),
-        
+
+        s.field("use_now_as_first_data_time", self.choice, false,
+                doc="Whether to use the current wallclock time for the timestamp of the first data frame"),
+
         s.field("set_t0_to", self.int8, -1,
                 doc="The first DAQ timestamp. If -1, t0 from file is used.")
 

--- a/schema/readoutlibs/sourceemulatorconfig.jsonnet
+++ b/schema/readoutlibs/sourceemulatorconfig.jsonnet
@@ -13,6 +13,9 @@ local s = moo.oschema.schema(ns);
 
 // Object structure used by the test/fake producer module
 local sourceemulatorconfig = {
+    size: s.number("Size", "u8",
+                   doc="A count of very many things"),
+
     uint4  : s.number("uint4", "u4",
                      doc="An unsigned of 4 bytes"),
 
@@ -67,6 +70,9 @@ local sourceemulatorconfig = {
 
         s.field("use_now_as_first_data_time", self.choice, false,
                 doc="Whether to use the current wallclock time for the timestamp of the first data frame"),
+
+        s.field("clock_speed_hz", self.size, 62500000,
+                doc="Clock frequency in Hz (for use in calculating the first data frame timestamp)"),
 
         s.field("set_t0_to", self.int8, -1,
                 doc="The first DAQ timestamp. If -1, t0 from file is used.")


### PR DESCRIPTION
Stated another way, this new option allows the use of the current wallclock time as the first data timestamp.

This PR should be tested and reviewed with a companion one in the `daqconf` package.  ( [number 304](https://github.com/DUNE-DAQ/daqconf/pull/304) )