### PR TITLE
FD/ND split of detdataformats

### DIFF
--- a/include/readoutlibs/models/detail/DefaultSkipListRequestHandler.hxx
+++ b/include/readoutlibs/models/detail/DefaultSkipListRequestHandler.hxx
@@ -16,8 +16,8 @@ DefaultSkipListRequestHandler<T>::skip_list_cleanup_request()
     auto tail = acc.last();
     auto head = acc.first();
     if (tail && head) {
-      // auto tailptr = reinterpret_cast<const detdataformats::daphne::DAPHNEFrame*>(tail); // NOLINT
-      // auto headptr = reinterpret_cast<const detdataformats::daphne::DAPHNEFrame*>(head); // NOLINT
+      // auto tailptr = reinterpret_cast<const fddetdataformats::DAPHNEFrame*>(tail); // NOLINT
+      // auto headptr = reinterpret_cast<const fddetdataformats::DAPHNEFrame*>(head); // NOLINT
       tailts = (*tail).get_first_timestamp(); // tailptr->get_timestamp();
       headts = (*head).get_first_timestamp(); // headptr->get_timestamp();
       TLOG_DEBUG(TLVL_WORK_STEPS) << "Cleanup REQUEST with "
@@ -34,7 +34,7 @@ DefaultSkipListRequestHandler<T>::skip_list_cleanup_request()
             ++removed_ctr;
           }
           head = acc.first();
-          // headptr = reinterpret_cast<const detdataformats::daphne::DAPHNEFrame*>(head);
+          // headptr = reinterpret_cast<const fddetdataformats::DAPHNEFrame*>(head);
           headts = (*head).get_first_timestamp(); // headptr->get_timestamp();
           timediff = tailts - headts;
         }


### PR DESCRIPTION
As the first step of the FD/ND release split, `detdataformats` is split into several new packages:
1. `fddetdataformats`
2. `nddetdataformats`
3. `trgdataformats`

The split involves relocation of headers, rename of namespaces, and updates to C
MakeLists.txt and config.cmake.in

This PR contains the necessary changes as a result of the split.

