### PR TITLE
Moved the test in SourceEmulatorModel::run_produce() that checks whet…

### DIFF
--- a/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
@@ -134,13 +134,13 @@ SourceEmulatorModel<ReadoutType>::run_produce()
   int dropout_index = 0;
 
   while (m_run_marker.load()) {
-    // Which element to push to the buffer
-    if (offset == num_elem * sizeof(ReadoutType) || (offset + 1) * sizeof(ReadoutType) > source.size()) {
-      offset = 0;
-    }
-
     // TLOG() << "Generating " << m_frames_per_tick << " for TS " << timestamp;
     for (uint16_t i = 0; i < m_frames_per_tick; i++) {
+      // Which element to push to the buffer
+      if (offset == num_elem || (offset + 1) * sizeof(ReadoutType) > source.size()) {
+        offset = 0;
+      }
+
       bool create_frame = m_dropouts[dropout_index]; // NOLINT(runtime/threadsafe_fn)
       dropout_index = (dropout_index + 1) % m_dropouts.size();
       if (create_frame) {


### PR DESCRIPTION
…her to reset the offset to zero inside the loop over frames_per_tick.

I've based this change/branch on a separate change/branch that only has clang-formatting of the SourceEmulatorModel.hxx file.  In that way, I hope to make it more clear  what the substantive changes were compared to formatting changes.

I noticed this problem when I was running tests of the TDE data format and I accidentally used the wrong emulated-data file.  In that case, the data in the file was not an integer number of TDE data packets and the bug caused the "for" loop over the frames_per_tick to run off the end of the file.  

In addition to moving the check on the value of the "offset" variable into "for" loop over the frames_per_tick, I changed the first condition in the "if" test.  Previously, it was " if (offset == num_elem * sizeof(ReadoutType)".  I believe that it should be "if (offset == num_elem" because "offset" is counting the number of data packets, not the number of bytes.