### PR TITLE
Handling consumer threads waits with an opportunistic sleep

### DIFF
--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -81,6 +81,7 @@ public:
     , m_send_partial_fragment_if_available(false)
     , m_consumer_thread(0)
     , m_raw_receiver_timeout_ms(0)
+    , m_raw_receiver_sleep_us(0)
     , m_raw_data_receiver(nullptr)
     , m_timesync_thread(0)
     , m_latency_buffer_impl(nullptr)
@@ -156,6 +157,7 @@ private:
 
   // RAW RECEIVER
   std::chrono::milliseconds m_raw_receiver_timeout_ms;
+  std::chrono::microseconds m_raw_receiver_sleep_us;
   using raw_receiver_ct = iomanager::ReceiverConcept<ReadoutType>;
   std::shared_ptr<raw_receiver_ct> m_raw_data_receiver;
 

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -214,7 +214,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::run_consume()
   while (m_run_marker.load()) {
     // Try to acquire data
 
-    auto opt_payload = m_raw_data_receiver->try_receive(std::chrono::milliseconds(0));
+    auto opt_payload = m_raw_data_receiver->try_receive(iomanager::Sender::s_no_block);
     if (opt_payload) {
 
       RDT& payload = opt_payload.value();


### PR DESCRIPTION
The folly wait results in a spin-waits that pushes the CPU consumption to 100%.
Tentative switch to a try_receive + sleep to reduce the CPU footprint.