### PR TITLE
Sequence id monitoring and consumer sleep/timeout control

### DIFF
--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -81,6 +81,7 @@ public:
     , m_send_partial_fragment_if_available(false)
     , m_consumer_thread(0)
     , m_raw_receiver_timeout_ms(0)
+    , m_raw_receiver_sleep_us(0)
     , m_raw_data_receiver(nullptr)
     , m_timesync_thread(0)
     , m_latency_buffer_impl(nullptr)
@@ -156,6 +157,7 @@ private:
 
   // RAW RECEIVER
   std::chrono::milliseconds m_raw_receiver_timeout_ms;
+  std::chrono::microseconds m_raw_receiver_sleep_us;
   using raw_receiver_ct = iomanager::ReceiverConcept<ReadoutType>;
   std::shared_ptr<raw_receiver_ct> m_raw_data_receiver;
 

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -231,7 +231,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::run_consume()
     } else {
       ++m_rawq_timeout_count;
       // Protection against a zero sleep becoming a yield
-      if ( m_raw_receiver_sleep_us != std::chrono::duration_values::zero)
+      if ( m_raw_receiver_sleep_us != std::chrono::microseconds::zero())
         std::this_thread::sleep_for(m_raw_receiver_sleep_us);
     }
 

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -74,7 +74,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::conf(const nlohmann::json& args)
     m_fake_trigger = true;
   }
   m_raw_receiver_timeout_ms = std::chrono::milliseconds(conf.source_queue_timeout_ms);
-  m_raw_receiver_sleep_us = std::chrono::microseconds(conf.source_queue_timeout_ms);
+  m_raw_receiver_sleep_us = std::chrono::microseconds(conf.source_queue_sleep_us);
   TLOG_DEBUG(TLVL_WORK_STEPS) << "ReadoutModel creation";
 
   m_sourceid.id = conf.source_id;

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -214,7 +214,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::run_consume()
   while (m_run_marker.load()) {
     // Try to acquire data
 
-    auto opt_payload = m_raw_data_receiver->try_receive(iomanager::Sender::s_no_block);
+    auto opt_payload = m_raw_data_receiver->try_receive(m_raw_receiver_timeout_ms);
     if (opt_payload) {
 
       RDT& payload = opt_payload.value();
@@ -230,8 +230,9 @@ ReadoutModel<RDT, RHT, LBT, RPT>::run_consume()
       ++m_stats_packet_count;
     } else {
       ++m_rawq_timeout_count;
-      std::this_thread::sleep_for(m_raw_receiver_sleep_us);
-      // std::this_thread::sleep_for(std::chrono::microseconds(1000));
+      // Protection against a zero sleep becoming a yield
+      if ( m_raw_receiver_sleep_us != std::chrono::duration_values::zero)
+        std::this_thread::sleep_for(m_raw_receiver_sleep_us);
     }
 
     // try {

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -214,7 +214,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::run_consume()
   while (m_run_marker.load()) {
     // Try to acquire data
 
-    auto opt_payload = m_raw_data_receiver->try_receive(std::chrono::milliseconds(0));
+    auto opt_payload = m_raw_data_receiver->try_receive(iomanager::Sender::s_no_block);
     if (opt_payload) {
 
       RDT& payload = opt_payload.value();

--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -133,6 +133,8 @@ local readoutconfig = {
                             doc="flag indicating whether to generate fake triggers: 1=true, 0=false "),
             s.field("source_queue_timeout_ms", self.count, 2000,
                             doc="Timeout for source queue"),
+            s.field("source_queue_sleep_us", self.count, 0,
+                            doc="Sleep for source us"),
             s.field("source_id", self.source_id, 0,
                             doc="The source id of this link"),
             s.field("tpset_min_latency_ticks", self.size, 3125000,

--- a/schema/readoutlibs/readoutinfo.jsonnet
+++ b/schema/readoutlibs/readoutinfo.jsonnet
@@ -6,13 +6,11 @@ local moo = import "moo.jsonnet";
 local s = moo.oschema.schema("dunedaq.readoutlibs.readoutinfo");
 
 local info = {
-    uint8  : s.number("uint8", "u8",
-                     doc="An unsigned of 8 bytes"),
-    float8 : s.number("float8", "f8",
-                      doc="A float of 8 bytes"),
+    int2   : s.number("int2", "i2", doc="An signed of 2 bytes"),
+    uint8  : s.number("uint8", "u8", doc="An unsigned of 8 bytes"),
+    float8 : s.number("float8", "f8", doc="A float of 8 bytes"),
     choice : s.boolean("Choice"),
-    string : s.string("String", moo.re.ident,
-                          doc="A string field"),
+    string : s.string("String", moo.re.ident, doc="A string field"),
 
    #latencybufferinfo: s.record("LatencyBufferInfo", [
 
@@ -26,6 +24,8 @@ local info = {
         s.field("rate_tp_hits",                  self.float8,    0, doc="TP hit rate in kHz"),
         s.field("num_frame_errors",              self.uint8,     0, doc="Total number of frame errors"),
         s.field("num_seq_id_errors",             self.uint8,     0, doc="Total number of sequence id frame errors"),
+        s.field("min_seq_id_jump",               self.int2,      0, doc="Minimum sequence-id jump"),
+        s.field("max_seq_id_jump",               self.int2,      0, doc="Maximum sequence-id jump"),
         s.field("num_ts_errors",                 self.uint8,     0, doc="Total number of timestamp frame errors")
    ], doc="Latency buffer information"),
 

--- a/schema/readoutlibs/readoutinfo.jsonnet
+++ b/schema/readoutlibs/readoutinfo.jsonnet
@@ -24,7 +24,9 @@ local info = {
         s.field("num_tps_dropped",               self.uint8,     0, doc="Number of dropped TPs (because they were too old)"),
         s.field("num_heartbeats",                self.uint8,     0, doc="Number of empty TP sets - heartbeats"),
         s.field("rate_tp_hits",                  self.float8,    0, doc="TP hit rate in kHz"),
-        s.field("num_frame_errors",              self.uint8,     0, doc="Total number of frame errors")
+        s.field("num_frame_errors",              self.uint8,     0, doc="Total number of frame errors"),
+        s.field("num_seq_id_errors",             self.uint8,     0, doc="Total number of sequence id frame errors"),
+        s.field("num_ts_errors",                 self.uint8,     0, doc="Total number of timestamp frame errors")
    ], doc="Latency buffer information"),
 
    tpchannelinfo: s.record("TPChannelInfo", [


### PR DESCRIPTION
This PR adds 2 new features to Readout Model
1. The capability to monitor sequence id errors in data streams using the DAQ-Ethernet headers.
    Specifically, the monitoring counters for sequence id errors, the minimum and maximum deviations
2. A configurable opportunistic sleep in the consumer thread loop (defaults=0, backwards compatible)
