### PR TITLE
Remove ADC generation from FrameProcessor

### DIFF
--- a/include/readoutlibs/models/SourceEmulatorModel.hpp
+++ b/include/readoutlibs/models/SourceEmulatorModel.hpp
@@ -165,6 +165,7 @@ private:
   std::vector<int> m_random_channels; 
   int m_pattern_index = 0;
   uint64_t m_pattern_generator_previous_ts = 0;  
+  int m_time_to_wait = 2140; // Adding a hit every 2140 gives a TP rate of approx 100 Hz/wire
 };
 
 } // namespace readoutlibs

--- a/include/readoutlibs/models/SourceEmulatorModel.hpp
+++ b/include/readoutlibs/models/SourceEmulatorModel.hpp
@@ -40,6 +40,33 @@ using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;
 namespace dunedaq {
 namespace readoutlibs {
 
+
+// Pattern generator class for creating different types of TP patterns
+// AAA: at the moment the pattern generator is very simple: random source id and random channel
+class SourceEmulatorPatternGenerator {
+
+public:
+  SourceEmulatorPatternGenerator() {
+    m_size = 1000000;
+  };
+  ~SourceEmulatorPatternGenerator() {};
+
+  void generate(int);
+
+  std::vector<int> get_channels() {
+    return m_channel;
+  }
+
+  int get_total_size() {
+    return m_size;
+  }
+ 
+private: 
+  int m_size;
+  std::vector<int> m_channel;
+};
+
+
 template<class ReadoutType>
 class SourceEmulatorModel : public SourceEmulatorConcept
 {
@@ -132,6 +159,12 @@ private:
   int m_crateid = 0;
   int m_slotid = 0;
   int m_linkid = 0;
+
+  // Pattern generator configs
+  SourceEmulatorPatternGenerator m_pattern_generator;
+  std::vector<int> m_random_channels; 
+  int m_pattern_index = 0;
+  uint64_t m_pattern_generator_previous_ts = 0;  
 };
 
 } // namespace readoutlibs

--- a/include/readoutlibs/models/SourceEmulatorModel.hpp
+++ b/include/readoutlibs/models/SourceEmulatorModel.hpp
@@ -165,7 +165,8 @@ private:
   std::vector<int> m_random_channels; 
   int m_pattern_index = 0;
   uint64_t m_pattern_generator_previous_ts = 0;  
-  int m_time_to_wait = 2140; // Adding a hit every 2140 gives a TP rate of approx 100 Hz/wire
+  // Adding a hit every 9768 gives a TP rate of approx 100 Hz/wire using WIBEthernet
+  int m_time_to_wait = 9768; 
 };
 
 } // namespace readoutlibs

--- a/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
@@ -1,10 +1,23 @@
 // Declarations for SourceEmulatorModel
+#include <iostream>
 
 using dunedaq::readoutlibs::logging::TLVL_TAKE_NOTE;
 using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;
 
 namespace dunedaq {
 namespace readoutlibs {
+
+void
+SourceEmulatorPatternGenerator::generate(int source_id)
+{
+  //TLOG() << "Generate random ADC patterns" ;
+  std::srand(source_id*12345678);
+  m_channel.reserve(m_size);
+  for (int i = 0; i < m_size; i++) {
+      int random_ch = std::rand()%64;
+      m_channel.push_back(random_ch);
+  }
+}
 
 template<class ReadoutType>
 void
@@ -60,6 +73,13 @@ SourceEmulatorModel<ReadoutType>::conf(const nlohmann::json& args, const nlohman
     m_frame_error_rate = m_link_conf.emu_frame_error_rate;
     m_error_bit_generator = ErrorBitGenerator(m_frame_error_rate);
     m_error_bit_generator.generate();
+
+    // Generate random ADC pattern
+    if (m_conf.generate_periodic_adc_pattern) {
+      TLOG() << "Generated pattern.";
+      m_pattern_generator.generate(m_sourceid.id);
+      m_random_channels = m_pattern_generator.get_channels();
+    }
 
     m_is_configured = true;
   }
@@ -163,6 +183,26 @@ SourceEmulatorModel<ReadoutType>::run_produce()
         }
         payload.fake_frame_errors(&frame_errs);
 
+        if (m_conf.generate_periodic_adc_pattern) {
+          // Adding a hit every 2298 gives a total Sent TP rate of approx 100 Hz/wire
+          if (timestamp - m_pattern_generator_previous_ts > 2298) {
+      
+            // Reset the pattern from the beginning if it reaches the maximum
+            m_pattern_index++;
+            if (m_pattern_index == m_pattern_generator.get_total_size()) {
+              m_pattern_index = 0;
+            }
+      
+            // Set the ADC to the uint16 maximum value
+            int channel = m_random_channels[m_pattern_index];
+            payload.fake_adc_pattern(channel);
+            //TLOG() << "Lift channel " << channel;
+      
+            // Update the previous timestamp of the pattern generator
+            m_pattern_generator_previous_ts = timestamp;
+          } // timestamp difference
+        }
+
         // send it
         try {
           m_raw_data_sender->send(std::move(payload), m_raw_sender_timeout_ms);
@@ -175,9 +215,13 @@ SourceEmulatorModel<ReadoutType>::run_produce()
         ++offset;
         ++m_packet_count;
         ++m_packet_count_tot;
+
+
       }
     }
     timestamp += m_time_tick_diff * rptr->get_num_frames();
+
+
 
     m_rate_limiter->limit();
   }

--- a/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
@@ -82,8 +82,8 @@ SourceEmulatorModel<ReadoutType>::conf(const nlohmann::json& args, const nlohman
       TLOG() << "TP rate per channel multiplier (base of 100 Hz/ch): " << m_conf.TP_rate_per_ch;
       if (m_conf.TP_rate_per_ch != 0) {
        // Define time to wait when adding an ADC above threshold
-       // Adding a hit every 2298 gives a total Sent TP rate of approx 100 Hz/wire
-        m_time_to_wait = 2140 / m_conf.TP_rate_per_ch;       
+       // Adding a hit every 9768 gives a total Sent TP rate of approx 100 Hz/wire with WIBEth
+        m_time_to_wait = m_time_to_wait / m_conf.TP_rate_per_ch;       
       }  
     }
 

--- a/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
+++ b/include/readoutlibs/models/detail/SourceEmulatorModel.hxx
@@ -1,5 +1,4 @@
 // Declarations for SourceEmulatorModel
-#include <iostream>
 
 using dunedaq::readoutlibs::logging::TLVL_TAKE_NOTE;
 using dunedaq::readoutlibs::logging::TLVL_WORK_STEPS;

--- a/schema/readoutlibs/sourceemulatorconfig.jsonnet
+++ b/schema/readoutlibs/sourceemulatorconfig.jsonnet
@@ -81,7 +81,10 @@ local sourceemulatorconfig = {
                 doc="Clock frequency in Hz (for use in calculating the first data frame timestamp)"),
 
         s.field("set_t0_to", self.int8, -1,
-                doc="The first DAQ timestamp. If -1, t0 from file is used.")
+                doc="The first DAQ timestamp. If -1, t0 from file is used."),
+        
+        s.field( "generate_periodic_adc_pattern", self.choice, false, 
+                doc="Generate a periodic ADC pattern inside the input data.")                
 
     ], doc="Fake Elink reader module configuration"),
 

--- a/schema/readoutlibs/sourceemulatorconfig.jsonnet
+++ b/schema/readoutlibs/sourceemulatorconfig.jsonnet
@@ -84,7 +84,10 @@ local sourceemulatorconfig = {
                 doc="The first DAQ timestamp. If -1, t0 from file is used."),
         
         s.field( "generate_periodic_adc_pattern", self.choice, false, 
-                doc="Generate a periodic ADC pattern inside the input data.")                
+                doc="Generate a periodic ADC pattern inside the input data."),                
+
+        s.field( "TP_rate_per_ch", self.size, 1, 
+                doc="Rate of TPs per channel when using a periodic ADC pattern generation. Values expresses as multiples of the expected rate of 100 Hz/ch.")                
 
     ], doc="Fake Elink reader module configuration"),
 


### PR DESCRIPTION
Removed ADC generation from FrameProcessors (pre-processing task) and added instead the ADC pattern generator in the SourceEmulatorModel.

A new DAQConf entry has been added for enabling the ADC pattern generation.

This fixes issues https://github.com/DUNE-DAQ/fdreadoutlibs/issues/110 and https://github.com/DUNE-DAQ/fdreadoutlibs/issues/124