### PR TITLE
Explicitly specified the TRACE_NAME in FrameErrorRegistry TLOG() calls

### DIFF
--- a/include/readoutlibs/FrameErrorRegistry.hpp
+++ b/include/readoutlibs/FrameErrorRegistry.hpp
@@ -44,7 +44,7 @@ public:
   {
     std::lock_guard<std::mutex> guard(m_error_map_mutex);
     if (m_errors.find(error_name) == m_errors.end()) {
-      TLOG() << "Encountered new error, name=\"" << error_name << "\"";
+      TLOG("FrameErrorRegistry") << "Encountered new error, name=\"" << error_name << "\"";
     }
     m_errors.erase(error_name);
     m_errors.insert(std::make_pair(error_name, error));
@@ -57,7 +57,7 @@ public:
       if (ts > it->second.end_ts) {
         std::string error_name = it->first;
         it = m_errors.erase(it);
-        TLOG() << "Removed error, name=\"" << error_name << "\"";
+        TLOG("FrameErrorRegistry") << "Removed error, name=\"" << error_name << "\"";
       } else {
         it++;
       }


### PR DESCRIPTION
… to avoid confusing TRACE memory buffer entries (e.g. showing TRACE_NAME of WIB2FrameProcessor when it should be WIBEthFrameProcessor).

While debugging a different problem, I noticed entries in the TRACE memory buffer that showed a TRACE_NAME of WIB2FrameProcessor.  This was very confusing because I was using emulated WIBEth data at the time.

I suspect that this TRACE_NAME was incorrectly being reported, and in fact, the error that was mentioned in the TRACE message came from the WIBEthFrameProcessor.

To prevent possible confusing messages like this, it seemed reasonable to explicitly specify a TRACE_NAME for FrameErrorRegistry TLOG messages, and that is what the changes in the PR do.