### PR TITLE
removed the source_id parameter from the LatencyBufferConf config

### DIFF
--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -53,9 +53,7 @@ local readoutconfig = {
             s.field("latency_buffer_alignment_size", self.count, 0,
                             doc="Alignment size of LB allocation"),
             s.field("latency_buffer_preallocation", self.choice, false,
-                            doc="Preallocate memory for the latency buffer"),
-            s.field("source_id", self.source_id, 0,
-                            doc="The source id of this link")],
+                            doc="Preallocate memory for the latency buffer")],
             doc="Latency Buffer Config"),
 
     rawdataprocessorconf : s.record("RawDataProcessorConf", [


### PR DESCRIPTION
…since it is not actually used by the code.

This PR is coupled with a companion one in the daqconf repo, so they should be tested and merged together.

I'm going to start out with this PR as a draft so that we can discuss it before moving forward with it.