### PR TITLE
Improved the Tardy-TP warning message and added suppression of it at start-run

### DIFF
--- a/include/readoutlibs/ReadoutIssues.hpp
+++ b/include/readoutlibs/ReadoutIssues.hpp
@@ -172,10 +172,12 @@ ERS_DECLARE_ISSUE(readoutlibs,
 
 ERS_DECLARE_ISSUE(readoutlibs,
                   DataPacketArrivedTooLate,
-                  "Received a late data packet in run " << run << ", payload first timestamp = " << ts1 <<
-                  ", request_handler cutoff timestamp = " << ts2 << ", difference = " << tick_diff <<
-                  " ticks, " << msec_diff << " msec.",
-                  ((daqdataformats::run_number_t)run)((daqdataformats::timestamp_t)ts1)((daqdataformats::timestamp_t)ts2)((int64_t)tick_diff)((double)msec_diff))
+                  "SourceID[" << sourceid << "] Received a late data packet in run " << run
+                  << ", the packet arrived " << msec_diff << " msec later than the allowed latency window of "
+                  << msec_allowed << " msec (" << ticks_allowed << " ticks).",
+                  ((daqdataformats::SourceID)sourceid)
+                  ((daqdataformats::run_number_t)run)((double)msec_diff)
+                  ((double)msec_allowed)((daqdataformats::timestamp_t)ticks_allowed))
 
 } // namespace dunedaq
 

--- a/include/readoutlibs/ReadoutIssues.hpp
+++ b/include/readoutlibs/ReadoutIssues.hpp
@@ -172,11 +172,10 @@ ERS_DECLARE_ISSUE(readoutlibs,
 
 ERS_DECLARE_ISSUE(readoutlibs,
                   DataPacketArrivedTooLate,
-                  "SourceID[" << sourceid << "] Received a late data packet in run " << run
-                  << ", the packet arrived " << msec_diff << " msec later than the allowed latency window of "
-                  << msec_allowed << " msec (" << ticks_allowed << " ticks).",
-                  ((daqdataformats::SourceID)sourceid)
-                  ((daqdataformats::run_number_t)run)((double)msec_diff)
+                  "SourceID[" << sid_subsystem << "," << sid_id << "] Received a late data packet, "
+                  << msec_diff << " ms beyond the allowed latency ("
+                  << msec_allowed << " ms, " << ticks_allowed << " ticks).",
+                  ((std::string)sid_subsystem)((daqdataformats::SourceID::ID_t)sid_id)((double)msec_diff)
                   ((double)msec_allowed)((daqdataformats::timestamp_t)ticks_allowed))
 
 } // namespace dunedaq

--- a/include/readoutlibs/ReadoutIssues.hpp
+++ b/include/readoutlibs/ReadoutIssues.hpp
@@ -170,14 +170,6 @@ ERS_DECLARE_ISSUE(readoutlibs,
                   "SourceID[" << sourceid << "] Empty fragment at the end of the run",
                   ((daqdataformats::SourceID)sourceid))
 
-ERS_DECLARE_ISSUE(readoutlibs,
-                  DataPacketArrivedTooLate,
-                  "SourceID[" << sid_subsystem << "," << sid_id << "] Received a late data packet, "
-                  << msec_diff << " ms beyond the allowed latency ("
-                  << msec_allowed << " ms, " << ticks_allowed << " ticks).",
-                  ((std::string)sid_subsystem)((daqdataformats::SourceID::ID_t)sid_id)((double)msec_diff)
-                  ((double)msec_allowed)((daqdataformats::timestamp_t)ticks_allowed))
-
 } // namespace dunedaq
 
 #endif // READOUTLIBS_INCLUDE_READOUTLIBS_READOUTISSUES_HPP_

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -152,8 +152,6 @@ public:
 
   virtual dunedaq::daqdataformats::timestamp_t get_cutoff_timestamp() {return 0;}
   virtual bool supports_cutoff_timestamp() {return false;}
-  virtual dunedaq::daqdataformats::timestamp_t get_allowed_latency() {return 0;}
-  virtual void increment_tardy_tp_count() {}
   virtual void report_tardy_packet(const RDT& /*packet*/, int64_t /*tardy_ticks*/) {}  // NOLINT
 
 protected:

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -152,6 +152,7 @@ public:
 
   virtual dunedaq::daqdataformats::timestamp_t get_cutoff_timestamp() {return 0;}
   virtual bool supports_cutoff_timestamp() {return false;}
+  virtual dunedaq::daqdataformats::timestamp_t get_allowed_latency() {return 0;}
   virtual void increment_tardy_tp_count() {}
 
 protected:

--- a/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
+++ b/include/readoutlibs/models/DefaultRequestHandlerModel.hpp
@@ -154,6 +154,7 @@ public:
   virtual bool supports_cutoff_timestamp() {return false;}
   virtual dunedaq::daqdataformats::timestamp_t get_allowed_latency() {return 0;}
   virtual void increment_tardy_tp_count() {}
+  virtual void report_tardy_packet(const RDT& /*packet*/, int64_t /*tardy_ticks*/) {}  // NOLINT
 
 protected:
   // An inline helper function that creates a fragment header based on a data request

--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -186,6 +186,7 @@ private:
   // REQUEST HANDLER
   std::unique_ptr<RequestHandlerType> m_request_handler_impl;
   bool m_request_handler_supports_cutoff_timestamp;
+  dunedaq::daqdataformats::timestamp_t m_request_handler_allowed_latency;
 
   // ERROR REGISTRY
   std::unique_ptr<FrameErrorRegistry> m_error_registry;

--- a/include/readoutlibs/models/ReadoutModel.hpp
+++ b/include/readoutlibs/models/ReadoutModel.hpp
@@ -186,7 +186,6 @@ private:
   // REQUEST HANDLER
   std::unique_ptr<RequestHandlerType> m_request_handler_impl;
   bool m_request_handler_supports_cutoff_timestamp;
-  dunedaq::daqdataformats::timestamp_t m_request_handler_allowed_latency;
 
   // ERROR REGISTRY
   std::unique_ptr<FrameErrorRegistry> m_error_registry;

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -113,7 +113,6 @@ ReadoutModel<RDT, RHT, LBT, RPT>::start(const nlohmann::json& args)
   m_num_payloads_overwritten = 0;
   m_stats_packet_count = 0;
   m_rawq_timeout_count = 0;
-  m_request_handler_allowed_latency = m_request_handler_impl->get_allowed_latency();
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
@@ -225,12 +224,7 @@ ReadoutModel<RDT, RHT, LBT, RPT>::run_consume()
       if (m_request_handler_supports_cutoff_timestamp) {
         int64_t diff1 = m_request_handler_impl->get_cutoff_timestamp() - payload.get_first_timestamp();
         if (diff1 >= 0) {
-          m_request_handler_impl->increment_tardy_tp_count();
           m_request_handler_impl->report_tardy_packet(payload, diff1);
-          ers::warning(DataPacketArrivedTooLate(ERS_HERE, daqdataformats::SourceID::subsystem_to_string(m_sourceid.subsystem),
-                                                m_sourceid.id, (static_cast<double>(diff1)/62500.0),
-                                                (static_cast<double>(m_request_handler_allowed_latency)/62500.0),
-                                                m_request_handler_allowed_latency));
         }
       }
       if (!m_latency_buffer_impl->write(std::move(payload))) {

--- a/include/readoutlibs/models/detail/ReadoutModel.hxx
+++ b/include/readoutlibs/models/detail/ReadoutModel.hxx
@@ -226,8 +226,9 @@ ReadoutModel<RDT, RHT, LBT, RPT>::run_consume()
         int64_t diff1 = m_request_handler_impl->get_cutoff_timestamp() - payload.get_first_timestamp();
         if (diff1 >= 0) {
           m_request_handler_impl->increment_tardy_tp_count();
-          ers::warning(DataPacketArrivedTooLate(ERS_HERE, m_sourceid, m_run_number,
-                                                (static_cast<double>(diff1)/62500.0),
+          m_request_handler_impl->report_tardy_packet(payload, diff1);
+          ers::warning(DataPacketArrivedTooLate(ERS_HERE, daqdataformats::SourceID::subsystem_to_string(m_sourceid.subsystem),
+                                                m_sourceid.id, (static_cast<double>(diff1)/62500.0),
                                                 (static_cast<double>(m_request_handler_allowed_latency)/62500.0),
                                                 m_request_handler_allowed_latency));
         }

--- a/schema/readoutlibs/readoutconfig.jsonnet
+++ b/schema/readoutlibs/readoutconfig.jsonnet
@@ -139,6 +139,8 @@ local readoutconfig = {
                             doc="Latency introduced to allow for TPs to arrive and be reordered, default is 50 ms"),
             s.field("tpset_transmission_rate_hz", self.size, 2000,
                             doc="Max rate at which TPSets are sent. Default is 2 kHz"),
+            s.field("tardy_tp_quiet_time_at_start_sec", self.count, 10,
+                            doc="Amount of time that warning messages about tardy TPs will be suppressed at the start of a run, default is 10s"),
             s.field("send_partial_fragment_if_available", self.choice, false,
                             doc="Whether to send a partial fragment if one is available")
     ], doc="Readout Model Config"),


### PR DESCRIPTION
The full set of changes for improving the Tardy TP warning messages are described in [fdreadoutlibs PR 166](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/166).  And, instructions for testing the changes are included in that PR.

This PR is coupled to ones in 3 other repos:  DUNE-DAQ/fdreadoutlibs#166], DUNE-DAQ/daqconf#434, and DUNE-DAQ/fddaqconf#28.  Changes in all 4 repos should be tested and eventually merged together.
